### PR TITLE
feat: add YOLO_MODE environment variable support for dangerously-skip…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ VITE_PORT=5173
 # When set to true, all features become accessible without login
 # WARNING: Only use in secure, private environments
 AUTH_DISABLED=false
+
+# Enable YOLO mode (dangerously skip permissions) (default: false)
+# When set to true, equivalent to --dangerously-skip-permissions flag
+# WARNING: This bypasses all permission prompts - use with extreme caution
+YOLO_MODE=false

--- a/server/claude-cli.js
+++ b/server/claude-cli.js
@@ -182,10 +182,14 @@ async function spawnClaude(command, options = {}, ws) {
     }
     
     // Add tools settings flags
+    // Check for YOLO mode from environment variable or settings
+    const yoloModeEnabled = process.env.YOLO_MODE === 'true' || settings.skipPermissions;
+    
     // Don't use --dangerously-skip-permissions when in plan mode
-    if (settings.skipPermissions && permissionMode !== 'plan') {
+    if (yoloModeEnabled && permissionMode !== 'plan') {
       args.push('--dangerously-skip-permissions');
-      console.log('⚠️  Using --dangerously-skip-permissions (skipping other tool settings)');
+      const source = process.env.YOLO_MODE === 'true' ? '(from YOLO_MODE env var)' : '(from UI settings)';
+      console.log(`⚠️  Using --dangerously-skip-permissions ${source} - skipping other tool settings`);
     } else {
       // Only add allowed/disallowed tools if not skipping permissions
       
@@ -221,8 +225,9 @@ async function spawnClaude(command, options = {}, ws) {
       }
       
       // Log when skip permissions is disabled due to plan mode
-      if (settings.skipPermissions && permissionMode === 'plan') {
-        console.log('📝 Skip permissions disabled due to plan mode');
+      if (yoloModeEnabled && permissionMode === 'plan') {
+        const source = process.env.YOLO_MODE === 'true' ? 'YOLO_MODE env var' : 'UI settings';
+        console.log(`📝 Skip permissions (${source}) disabled due to plan mode`);
       }
     }
     

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -44,10 +44,14 @@ async function spawnCursor(command, options = {}, ws) {
       args.push('--output-format', 'stream-json');
     }
     
-    // Add skip permissions flag if enabled
-    if (skipPermissions || settings.skipPermissions) {
+    // Add skip permissions flag if enabled (check env var, parameter, or settings)
+    const yoloModeEnabled = process.env.YOLO_MODE === 'true' || skipPermissions || settings.skipPermissions;
+    if (yoloModeEnabled) {
       args.push('-f');
-      console.log('⚠️  Using -f flag (skip permissions)');
+      let source = 'UI settings';
+      if (process.env.YOLO_MODE === 'true') source = 'YOLO_MODE env var';
+      else if (skipPermissions) source = 'parameter';
+      console.log(`⚠️  Using -f flag (skip permissions from ${source})`);
     }
     
     // Use cwd (actual project directory) instead of projectPath

--- a/server/index.js
+++ b/server/index.js
@@ -203,7 +203,8 @@ app.get('/api/config', authenticateToken, (req, res) => {
 
     res.json({
         serverPort: PORT,
-        wsUrl: `${protocol}://${host}`
+        wsUrl: `${protocol}://${host}`,
+        yoloModeEnabled: process.env.YOLO_MODE === 'true'
     });
 });
 

--- a/src/components/ToolsSettings.jsx
+++ b/src/components/ToolsSettings.jsx
@@ -12,6 +12,7 @@ function ToolsSettings({ isOpen, onClose, projects = [] }) {
   const [newAllowedTool, setNewAllowedTool] = useState('');
   const [newDisallowedTool, setNewDisallowedTool] = useState('');
   const [skipPermissions, setSkipPermissions] = useState(false);
+  const [yoloModeFromEnv, setYoloModeFromEnv] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState(null);
   const [projectSortOrder, setProjectSortOrder] = useState('name');
@@ -330,6 +331,23 @@ function ToolsSettings({ isOpen, onClose, projects = [] }) {
         setDisallowedTools([]);
         setSkipPermissions(false);
         setProjectSortOrder('name');
+      }
+      
+      // Check for YOLO mode from server config
+      try {
+        const configResponse = await fetch('/api/config', {
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        });
+        if (configResponse.ok) {
+          const config = await configResponse.json();
+          setYoloModeFromEnv(config.yoloModeEnabled || false);
+        }
+      } catch (error) {
+        console.warn('Failed to fetch config:', error);
+        setYoloModeFromEnv(false);
       }
       
       // Load Cursor settings from localStorage
@@ -753,14 +771,25 @@ function ToolsSettings({ isOpen, onClose, projects = [] }) {
                     type="checkbox"
                     checked={skipPermissions}
                     onChange={(e) => setSkipPermissions(e.target.checked)}
-                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                    disabled={yoloModeFromEnv}
+                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 disabled:opacity-50"
                   />
                   <div>
                     <div className="font-medium text-orange-900 dark:text-orange-100">
                       Skip permission prompts (use with caution)
+                      {yoloModeFromEnv && (
+                        <Badge variant="secondary" className="ml-2 bg-orange-200 dark:bg-orange-800 text-orange-800 dark:text-orange-200">
+                          ENV
+                        </Badge>
+                      )}
                     </div>
                     <div className="text-sm text-orange-700 dark:text-orange-300">
                       Equivalent to --dangerously-skip-permissions flag
+                      {yoloModeFromEnv && (
+                        <div className="mt-1 text-orange-600 dark:text-orange-400 font-medium">
+                          ⚠️ YOLO mode is enabled via YOLO_MODE environment variable
+                        </div>
+                      )}
                     </div>
                   </div>
                 </label>


### PR DESCRIPTION
…-permissions

- Add YOLO_MODE environment variable to .env.example with proper warnings
- Update claude-cli.js to check YOLO_MODE env var or UI settings
- Update cursor-cli.js to support YOLO_MODE env var with source tracking
- Add yoloModeEnabled flag to /api/config endpoint
- Update ToolsSettings.jsx to show when YOLO mode is enabled via env var
- Disable UI checkbox and show ENV badge when controlled by environment
- Add clear warning message when YOLO_MODE is set via environment variable
- Maintain backward compatibility with existing UI-based skipPermissions setting

This allows administrators to enable YOLO mode (--dangerously-skip-permissions) via environment configuration instead of requiring manual UI changes.

🤖 Generated with [Claude Code](https://claude.ai/code)